### PR TITLE
support for http_proxy & spectool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Jamie Curnow <jc@jc21.com>"
 # Yum
 RUN yum -y install epel-release drpm dnf-plugins-core \
   && dnf config-manager --set-enabled PowerTools \
-  && yum localinstall -y https://yum.jc21.com/jc21-yum.rpm
+  && yum localinstall -y https://yum.jc21.com/jc21-yum.rpm \
   && yum -y update \
   && yum -y install scl-utils scl-utils-build which mock git wget curl kernel-devel rpmdevtools rpmlint rpm-build sudo gcc-c++ make automake autoconf yum-utils scl-utils scl-utils-build cmake libtool expect \
   && yum -y install aspell-devel bzip2-devel chrpath cyrus-sasl-devel enchant-devel fastlz-devel fontconfig-devel freetype-devel gettext-devel gmp-devel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN chown root:root /etc/sudoers.d/*
 
 # Remove requiretty from sudoers main file
 RUN sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers
+RUN sed -i '/Defaults.*XAUTHORITY"/a Defaults    env_keep += "HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy"' /etc/sudoers
 
 # Rpm User
 RUN adduser -G wheel rpmbuilder \

--- a/bin/build-spec
+++ b/bin/build-spec
@@ -112,8 +112,6 @@ fi
 sudo yum clean all
 sudo rm -rf /var/cache/yum
 
-cd ~/rpmbuild
-
 ## Disable yum mirror if specified
 if [ -n "$nomirror" ]; then
     echo -e "${YELLOW}❯ ${GREEN}Disabling Yum Fastest Mirror Plugin ...${RESET}"
@@ -145,8 +143,14 @@ fi
 echo -e "${YELLOW}❯ ${GREEN}Building ${WHITE}$@ ${GREEN}...${RESET}"
 cd ~/rpmbuild
 
-sudo yum-builddep -y $1
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+for spec in "$@"
+do
+    sudo yum-builddep -y ${spec}
+    rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
-rpmbuild --clean -ba $@
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+    spectool -g -R ${spec}
+    rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+
+    rpmbuild --clean -ba ${spec}
+    rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+done


### PR DESCRIPTION
It would be nice if these changes could be included in your image:
* keep http_proxy for sudo commands
* missing trailing backslash after jc21-yum.rpm
* spectool for sources that need to be downloaded. Example: node_exporter (https://github.com/lest/prometheus-rpm)
  * I also adapted it to loop all spec files as this is needed by spectool (and I believe also for yum-builddep -> it still had $1 as parameter)
